### PR TITLE
Correct spelling of "elfojtás" in text

### DIFF
--- a/index.html
+++ b/index.html
@@ -316,7 +316,7 @@
 	<li><p>Így is megtelnek az intenzív osztályok. Hónapokra. (És ne feledd, <em>már korábban</em> megháromszoroztuk őket az ilyen esetekre.)</p></li>
 	</ol>
 
-	<p>Ez volt a másik eredménye az Imperial College március 16-i jelentésének, ami meggyőzte az Egyesült Királyságot, hogy mondjon le eredeti tervéről. A <strong>mérséklésre</strong> való bármilyen törekvés (ami következményeképp R értéke csökken, de R &gt; 1 marad) kudarcot vall. Az egyedüli lehetőség az <strong>elfolytás</strong> (ami következményeképp R értéke 1 alá csökken; R &lt; 1).</p>
+	<p>Ez volt a másik eredménye az Imperial College március 16-i jelentésének, ami meggyőzte az Egyesült Királyságot, hogy mondjon le eredeti tervéről. A <strong>mérséklésre</strong> való bármilyen törekvés (ami következményeképp R értéke csökken, de R &gt; 1 marad) kudarcot vall. Az egyedüli lehetőség az <strong>elfojtás</strong> (ami következményeképp R értéke 1 alá csökken; R &lt; 1).</p>
 
 	<p><img src="pics/mitigation_vs_suppression.png" alt=""></p>
 


### PR DESCRIPTION
Hi @jusplathemus,

You are super awesome for translating the whole thing to Hungarian! Your style is impeccable! I'm grateful that I managed to send it to a couple of non-English speaking friends. However one of them pointed out this spelling error about "elfojtás".

"Fojt" means to choke, stifle, strangle, while "folyt" is the past tense of "folyik".

https://en.wiktionary.org/wiki/fojt vs. https://en.wiktionary.org/wiki/folyt#Hungarian

While this doesn't bother me, it seems it takes away from the message for the more grammar naz... umm... aware audience.

I fixed the text one, but I can't figure out what font did you use in the picture here: https://jusplathemus.github.io/covid-19/pics/mitigation_vs_suppression.png

Would be happy to edit and add the image to this pull request if you can point me to the font. Or just fix it yourself it it's more simple for you.

Thanks again,
Attila